### PR TITLE
fix: support polymorphic navigation properties in @odata.bind validation (0.1.7)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.6-slim
+FROM python:3.11-slim
 ENV PYTHONIOENCODING utf-8
 
 COPY . /code/

--- a/change_log.md
+++ b/change_log.md
@@ -1,3 +1,8 @@
+**0.1.7**
+FIX: Support polymorphic (multi-table) lookup fields via `@odata.bind` navigation properties.
+Fields like `customerid_account@odata.bind` on the Incident entity are now validated against
+both regular entity attributes and single-valued navigation properties (ManyToOneRelationships).
+
 **0.1.1**
 Fixed public links in documentation.
 MINOR: Tweaks to configuration schema to open links in new tab.

--- a/src/component.py
+++ b/src/component.py
@@ -8,7 +8,7 @@ from configuration import Configuration
 from dynamics.client import DynamicsClient
 from dynamics.result import DynamicsResultsWriter
 
-APP_VERSION = '0.1.3'
+APP_VERSION = '0.1.7'
 
 SUPPORTED_OPERATIONS = ['delete', 'create_and_update', 'upsert']
 MANDATORYFIELDS_UPSERT = ['id', 'data']

--- a/src/component.py
+++ b/src/component.py
@@ -183,8 +183,10 @@ class Component(ComponentBase):
             table_name = table.name.replace('.csv', '').lower()
             endpoint = self._client.supported_endpoints[table_name]
             supported_attributes = self._client.get_endpoint_attributes(endpoint)
+            navigation_properties = self._client.get_endpoint_navigation_properties(endpoint)
 
             logging.info(f"Supported attributes for {endpoint}: {supported_attributes}")
+            logging.info(f"Supported navigation properties for {endpoint}: {navigation_properties}")
 
             with open(table.full_path) as inTable:
                 table_reader = csv.DictReader(inTable)
@@ -208,8 +210,16 @@ class Component(ComponentBase):
 
                     if record_operation != 'delete':
                         record_data = self.parse_json_from_string(row['data'])
-                        record_keys = [key.replace("@odata.bind", "") for key in record_data.keys()]
-                        missing = [item for item in record_keys if item not in supported_attributes]
+                        missing = []
+                        for key in record_data.keys():
+                            stripped_key = key.replace("@odata.bind", "")
+                            if "@odata.bind" in key:
+                                if stripped_key not in supported_attributes \
+                                        and stripped_key not in navigation_properties:
+                                    missing.append(stripped_key)
+                            else:
+                                if stripped_key not in supported_attributes:
+                                    missing.append(stripped_key)
 
                         if missing:
                             raise UserException(f"In {table.name} on the line {row_counter} are"

--- a/src/dynamics/client.py
+++ b/src/dynamics/client.py
@@ -117,6 +117,29 @@ class DynamicsClient(HttpClient):
         except requests.HTTPError as e:
             raise e
 
+    def get_endpoint_navigation_properties(self, entity_name: str) -> list:
+
+        url = os.path.join(
+            self.base_url,
+            f'EntityDefinitions(LogicalName=\'{entity_name}\')/ManyToOneRelationships'
+            f'?$select=ReferencingEntityNavigationPropertyName'
+        )
+
+        response = self.get_raw(url, is_absolute_path=True)
+
+        try:
+            response.raise_for_status()
+            json_data = response.json()
+
+            nav_properties = [rel.get('ReferencingEntityNavigationPropertyName')
+                              for rel in json_data.get('value', [])
+                              if rel.get('ReferencingEntityNavigationPropertyName')]
+
+            return nav_properties
+
+        except requests.HTTPError as e:
+            raise e
+
     def create_record(self, endpoint, data):
         url_create = os.path.join(self.base_url, endpoint)
         data_create = data

--- a/src/dynamics/client.py
+++ b/src/dynamics/client.py
@@ -122,10 +122,13 @@ class DynamicsClient(HttpClient):
         url = os.path.join(
             self.base_url,
             f'EntityDefinitions(LogicalName=\'{entity_name}\')/ManyToOneRelationships'
-            f'?$select=ReferencingEntityNavigationPropertyName'
         )
 
-        response = self.get_raw(url, is_absolute_path=True)
+        params = {
+            '$select': 'ReferencingEntityNavigationPropertyName'
+        }
+
+        response = self.get_raw(url, is_absolute_path=True, params=params)
 
         try:
             response.raise_for_status()

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -1,0 +1,162 @@
+import csv
+import json
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import MagicMock
+
+import requests
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from dynamics.client import DynamicsClient  # noqa: E402
+from keboola.component.exceptions import UserException  # noqa: E402
+
+
+class TestGetEndpointNavigationProperties(unittest.TestCase):
+    """Unit tests for DynamicsClient.get_endpoint_navigation_properties."""
+
+    def setUp(self):
+        self.client = DynamicsClient.__new__(DynamicsClient)
+        self.client.base_url = 'https://org.crm.dynamics.com/api/data/v9.2/'
+
+    def _mock_ok_response(self, value_list):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.json.return_value = {'value': value_list}
+        return mock_resp
+
+    def test_returns_navigation_property_names(self):
+        self.client.get_raw = MagicMock(return_value=self._mock_ok_response([
+            {'ReferencingEntityNavigationPropertyName': 'customerid_account'},
+            {'ReferencingEntityNavigationPropertyName': 'customerid_contact'},
+        ]))
+        result = self.client.get_endpoint_navigation_properties('incident')
+        self.assertIn('customerid_account', result)
+        self.assertIn('customerid_contact', result)
+        self.assertEqual(len(result), 2)
+
+    def test_filters_empty_nav_property_names(self):
+        self.client.get_raw = MagicMock(return_value=self._mock_ok_response([
+            {'ReferencingEntityNavigationPropertyName': 'customerid_account'},
+            {'ReferencingEntityNavigationPropertyName': ''},
+            {'ReferencingEntityNavigationPropertyName': None},
+            {},
+        ]))
+        result = self.client.get_endpoint_navigation_properties('incident')
+        self.assertEqual(result, ['customerid_account'])
+
+    def test_empty_response_returns_empty_list(self):
+        self.client.get_raw = MagicMock(return_value=self._mock_ok_response([]))
+        result = self.client.get_endpoint_navigation_properties('incident')
+        self.assertEqual(result, [])
+
+    def test_http_error_is_propagated(self):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.side_effect = requests.HTTPError('403 Forbidden')
+        self.client.get_raw = MagicMock(return_value=mock_resp)
+        with self.assertRaises(requests.HTTPError):
+            self.client.get_endpoint_navigation_properties('incident')
+
+
+class TestCheckInputAttributes(unittest.TestCase):
+    """Tests for the polymorphic @odata.bind validation in check_input_attributes."""
+
+    def _build_component(self, table_name, rows, supported_attrs, nav_properties, operation='upsert'):
+        tmp_dir = tempfile.mkdtemp()
+        csv_path = os.path.join(tmp_dir, f'{table_name}.csv')
+        with open(csv_path, 'w', newline='') as f:
+            writer = csv.DictWriter(f, fieldnames=['id', 'data'])
+            writer.writeheader()
+            for row in rows:
+                writer.writerow({
+                    'id': row.get('id', 'test-uuid'),
+                    'data': json.dumps(row['data']),
+                })
+
+        mock_table = MagicMock()
+        mock_table.name = f'{table_name}.csv'
+        mock_table.full_path = csv_path
+
+        mock_client = MagicMock()
+        mock_client.supported_endpoints = {table_name: table_name}
+        mock_client.get_endpoint_attributes.return_value = supported_attrs
+        mock_client.get_endpoint_navigation_properties.return_value = nav_properties
+
+        mock_cfg = MagicMock()
+        mock_cfg.operation = operation
+
+        from component import Component
+        comp = Component.__new__(Component)
+        comp.in_tables = [mock_table]
+        comp._client = mock_client
+        comp.cfg = mock_cfg
+        return comp
+
+    def test_polymorphic_nav_property_odata_bind_is_accepted(self):
+        """customerid_account@odata.bind passes when customerid_account is a nav property."""
+        comp = self._build_component(
+            'incidents',
+            [{'id': 'abc', 'data': {'customerid_account@odata.bind': '/accounts(xyz)'}}],
+            supported_attrs=['title', 'description'],
+            nav_properties=['customerid_account', 'customerid_contact'],
+        )
+        comp.check_input_attributes()  # must not raise
+
+    def test_regular_odata_bind_on_attribute_is_accepted(self):
+        """Standard @odata.bind on a regular entity attribute still passes."""
+        comp = self._build_component(
+            'incidents',
+            [{'id': 'abc', 'data': {'mil_incidentcategoryl1id@odata.bind': '/mil_incidentcategories(xyz)'}}],
+            supported_attrs=['mil_incidentcategoryl1id', 'title'],
+            nav_properties=[],
+        )
+        comp.check_input_attributes()  # must not raise
+
+    def test_invalid_odata_bind_key_is_rejected(self):
+        """A typo in an @odata.bind key is caught and raises UserException."""
+        comp = self._build_component(
+            'incidents',
+            [{'id': 'abc', 'data': {'nonexistent_field@odata.bind': '/something(xyz)'}}],
+            supported_attrs=['title'],
+            nav_properties=['customerid_account'],
+        )
+        with self.assertRaises(UserException):
+            comp.check_input_attributes()
+
+    def test_regular_supported_attribute_is_accepted(self):
+        """Plain field present in supported_attrs passes without error."""
+        comp = self._build_component(
+            'incidents',
+            [{'id': 'abc', 'data': {'title': 'Test', 'description': 'Desc'}}],
+            supported_attrs=['title', 'description'],
+            nav_properties=[],
+        )
+        comp.check_input_attributes()  # must not raise
+
+    def test_unsupported_plain_attribute_is_rejected(self):
+        """Plain field absent from supported_attrs raises UserException."""
+        comp = self._build_component(
+            'incidents',
+            [{'id': 'abc', 'data': {'title': 'Test', 'notanattr': 'value'}}],
+            supported_attrs=['title'],
+            nav_properties=[],
+        )
+        with self.assertRaises(UserException):
+            comp.check_input_attributes()
+
+    def test_delete_operation_skips_attribute_validation(self):
+        """Delete rows bypass attribute validation entirely."""
+        comp = self._build_component(
+            'incidents',
+            [{'id': 'some-id', 'data': {}}],
+            supported_attrs=[],
+            nav_properties=[],
+            operation='delete',
+        )
+        comp.check_input_attributes()  # must not raise
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- Fixes rejection of valid polymorphic `@odata.bind` keys (e.g. `customerid_account@odata.bind`) on the Dynamics 365 Incident entity
- New `get_endpoint_navigation_properties()` fetches `ManyToOneRelationships` metadata so the validation accepts navigation property names alongside regular entity attributes
- Upgrades base Docker image from `python:3.8.6-slim` (Debian Buster, EOL) to `python:3.11-slim` — the old image's apt repos return 404s and broke the build
- Adds 10 unit tests covering the new validation logic

## Closes

CFTL-658 / SUPPORT-16423

## Test plan

- [ ] CI passes (Run Tests + Docker Image Build)
- [ ] Merge and tag `0.1.7` on main to deploy
- [ ] Customer verifies `customerid_account@odata.bind` against the Incident entity in the SLSP project

🤖 Generated with [Claude Code](https://claude.com/claude-code)