### PR TITLE
fix: derive Dynamics entity name from on-disk filename (CFTL-658)

### DIFF
--- a/src/component.py
+++ b/src/component.py
@@ -2,6 +2,7 @@ import csv
 import json
 import logging
 import os
+from pathlib import Path
 
 from keboola.component.base import ComponentBase
 from keboola.component.exceptions import UserException
@@ -39,7 +40,7 @@ class Component(ComponentBase):
         self.check_input_attributes()
 
         for table in self.in_tables:
-            endpoint = table.name.replace(".csv", "")
+            endpoint = self._entity_set_name(table)
 
             logging.info(f"Writing data to {endpoint}.")
             error_counter = 0
@@ -184,12 +185,25 @@ class Component(ComponentBase):
         if len(tables_with_missing_fields) != 0:
             raise UserException(f"Mandatory fields {mand_fields_set} missing in tables {tables_with_missing_fields}.")
 
+    @staticmethod
+    def _entity_set_name(table) -> str:
+        """Derive the Dynamics entity set name from the on-disk filename.
+
+        The entity set is encoded in the input table's file name (e.g.
+        ``incidents.csv`` -> ``incidents``). We read it from ``full_path``
+        rather than ``table.name`` because keboola-component >=1.5 overrides
+        ``TableDefinition.name`` with the Storage table name from the manifest,
+        which is unrelated to the Dynamics entity. ``Path.stem`` handles both a
+        plain CSV file and a sliced-table directory. See CFTL-658.
+        """
+        return Path(table.full_path).stem
+
     def check_input_endpoints(self):
 
         unsupported_endpoints = []
 
         for table in self.in_tables:
-            endpoint = table.name.replace(".csv", "").lower()
+            endpoint = self._entity_set_name(table).lower()
             if endpoint not in list(self._client.supported_endpoints.keys()):
                 unsupported_endpoints += [endpoint]
 
@@ -211,7 +225,7 @@ class Component(ComponentBase):
     def check_input_attributes(self):
 
         for table in self.in_tables:
-            table_name = table.name.replace(".csv", "").lower()
+            table_name = self._entity_set_name(table).lower()
             endpoint = self._client.supported_endpoints[table_name]
             supported_attributes = self._client.get_endpoint_attributes(endpoint)
             navigation_properties = self._client.get_endpoint_navigation_properties(endpoint)

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -170,5 +170,104 @@ class TestCheckInputAttributes(unittest.TestCase):
         comp.check_input_attributes()  # must not raise
 
 
+class TestEntitySetNameDerivation(unittest.TestCase):
+    """Regression tests for CFTL-658.
+
+    keboola-component >=1.5 overrides ``TableDefinition.name`` with the Storage
+    table name from the manifest, which is unrelated to the Dynamics entity set.
+    The entity set must be derived from the on-disk filename (``full_path``), not
+    ``table.name``, otherwise every config whose Storage table name differs from
+    the entity set name fails endpoint validation.
+
+    These tests build a *real* ``TableDefinition`` via the installed
+    keboola-component library (no hand-set mock for ``name``) so they both
+    reproduce the library's behaviour and prove the fix against the real object.
+    """
+
+    STORAGE_NAME = "FINAL_REMIND_ME_PROD_ACCOUNT_GUID"
+
+    def _real_table(self, on_disk_filename, rows=None, sliced=False):
+        """Build a real TableDefinition whose Storage name differs from its filename.
+
+        Writes an on-disk table named ``on_disk_filename`` plus a manifest whose
+        ``name`` is the unrelated Storage table name, then lets the real library
+        construct the TableDefinition exactly as ``get_input_tables_definitions``
+        does.
+        """
+        from keboola.component.dao import TableDefinition
+
+        tmp_dir = tempfile.mkdtemp()
+        data_path = os.path.join(tmp_dir, on_disk_filename)
+
+        if sliced:
+            os.makedirs(data_path)
+            with open(os.path.join(data_path, "part-0.csv"), "w", newline="") as f:
+                self._write_rows(f, rows)
+        else:
+            with open(data_path, "w", newline="") as f:
+                self._write_rows(f, rows)
+
+        manifest_path = data_path + ".manifest"
+        with open(manifest_path, "w") as f:
+            json.dump({"id": f"in.c-bucket.{self.STORAGE_NAME}", "name": self.STORAGE_NAME}, f)
+
+        table = TableDefinition.build_from_manifest(manifest_path)
+        # Guard: confirm the library really does override name with the Storage
+        # name in the installed version — otherwise the test proves nothing.
+        self.assertEqual(table.name, self.STORAGE_NAME)
+        return table
+
+    @staticmethod
+    def _write_rows(f, rows):
+        writer = csv.DictWriter(f, fieldnames=["id", "data"])
+        writer.writeheader()
+        for row in rows or []:
+            writer.writerow({"id": row.get("id", "test-uuid"), "data": json.dumps(row["data"])})
+
+    def _component_for(self, table, supported_endpoints, supported_attrs=None, nav_properties=None):
+        mock_client = MagicMock()
+        mock_client.supported_endpoints = supported_endpoints
+        mock_client.get_endpoint_attributes.return_value = supported_attrs or []
+        mock_client.get_endpoint_navigation_properties.return_value = nav_properties or []
+
+        mock_cfg = MagicMock()
+        mock_cfg.operation = "upsert"
+
+        from component import Component
+
+        comp = Component.__new__(Component)
+        comp.in_tables = [table]
+        comp._client = mock_client
+        comp.cfg = mock_cfg
+        return comp
+
+    def test_entity_set_name_uses_filename_not_storage_name(self):
+        from component import Component
+
+        table = self._real_table("incidents.csv")
+        self.assertEqual(Component._entity_set_name(table), "incidents")
+
+    def test_entity_set_name_for_sliced_table_directory(self):
+        from component import Component
+
+        table = self._real_table("incidents", sliced=True)
+        self.assertEqual(Component._entity_set_name(table), "incidents")
+
+    def test_check_input_endpoints_resolves_filename_over_storage_name(self):
+        """The bug: endpoint validation rejected the Storage name. It must use the filename."""
+        table = self._real_table("incidents.csv")
+        comp = self._component_for(table, supported_endpoints={"incidents": "incident"})
+        comp.check_input_endpoints()  # must not raise
+
+    def test_check_input_attributes_resolves_filename_over_storage_name(self):
+        table = self._real_table("incidents.csv", rows=[{"id": "abc", "data": {"title": "Test"}}])
+        comp = self._component_for(
+            table,
+            supported_endpoints={"incidents": "incident"},
+            supported_attrs=["title"],
+        )
+        comp.check_input_attributes()  # must not raise
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

`kds-team.wr-microsoft-dynamics` started failing for **all** configs whose Storage table name differs from the Dynamics entity set name, with errors like:

> Some endpoints are not available in the Dynamics CRM API instance. Unsupported endpoints: ['final_remind_me_prod_account_guid']

This is a **regression introduced by the uv/tooling modernization** (merged via PR #9), which bumped `keboola-component` from a pinned `1.4.3` to `>=1.4.3` → resolved `1.10.0`.

In `keboola-component` 1.10.0, `TableDefinition.name` was changed to return the **Storage table name** from the manifest instead of the **on-disk filename**:

```python
if file_path.exists():
    name = file_path.name        # 1.4.3: on-disk filename, e.g. "accounts.csv"
...
if manifest.get("name"):
    name = manifest.get("name")  # 1.10.0: overrides with Storage table name
```

The writer derives the Dynamics entity set name from the table name (3 sites), so it began resolving to the Storage table name (e.g. `final_remind_me_prod_account_guid`) instead of the entity (`accounts`), and endpoint validation rejected every such table.

## Fix

Derive the entity set name from `Path(table.full_path).stem` — the on-disk filename — via a single `_entity_set_name()` helper, applied at all three derivation sites. This restores the exact pre-1.10.0 behaviour and is independent of the library version. Handles both plain CSV files and sliced-table directories.

Display-only error messages keep using `table.name` (showing the Storage table name there is more useful for identifying the source).

## Tests

New regression tests build a **real** `TableDefinition` via the installed `keboola-component` library (no hand-set mocks), so they:
- reproduce the library's name override in the installed version, and
- prove the fix against the real object, end-to-end through `check_input_endpoints` / `check_input_attributes`.

Verified the new tests **fail against the old logic** with the exact production error, then pass with the fix. Full suite: 14 passed; `ruff` clean.

Closes CFTL-658.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
